### PR TITLE
Update call() method to accept all __soapCall() method arguments

### DIFF
--- a/src/Exfoliate/SoapClient.php
+++ b/src/Exfoliate/SoapClient.php
@@ -52,18 +52,21 @@ class SoapClient implements ClientInterface
     /**
      * @param string $method
      * @param mixed $data
+     * @param array $options
+     * @param null $inputHeaders
+     * @param null $outputHeaders
      *
      * @throws Exception\ClientException
      * @return mixed
      */
-    public function call($method, $data)
+    public function call($method, $data, $options = array(), $inputHeaders = null, &$outputHeaders = null)
     {
         if (!$this->client) {
             $this->initializeClient();
         }
 
         try {
-            return $this->client->__soapCall($method, $data);
+            return $this->client->__soapCall($method, $data, $options, $inputHeaders, $outputHeaders);
         } catch (\SoapFault $soapFault) {
             throw new ClientException(sprintf('Call to %s failed', $method), 0, $soapFault);
         }

--- a/tests/Exfoliate/Tests/SoapClientTest.php
+++ b/tests/Exfoliate/Tests/SoapClientTest.php
@@ -62,16 +62,19 @@ class SoapClientTest extends \PHPUnit_Framework_TestCase
     {
         $method = 'method';
         $data = array('data_element' => 'element_value');
+        $options = array('soapaction' => 'some_action', 'uri' => 'some_uri');
+        $inputHeaders = new \SoapHeader('http://soapinterop.org/echoheader/', 'echoMeStringRequest');
+        $outputHeaders = array('data_element' => 'element_value');
 
         $this->factoryClient->expects($this->once())
             ->method('__soapCall')
-            ->with($method, $data);
+            ->with($method, $data, $options, $inputHeaders, $outputHeaders);
 
         $this->factory->expects($this->once())
             ->method('create')
             ->will($this->returnValue($this->factoryClient));
 
-        $this->client->call($method, $data);
+        $this->client->call($method, $data, $options, $inputHeaders, $outputHeaders);
     }
 
     public function testConnectionSoapFaultsThrowConnectionException()


### PR DESCRIPTION
Exfoliate only utilizes the first two arguments in the __soapCall() method of SoapClient.

This pull request suggests implementing the rest of the arguments in the call() method.

Developers very well may need to utilize the options, input headers, and output header parameters to make their soap function work properly with __soapCall(). Just like __soapCall(), these additional parameters are completely optional. Nobody will have to modify any code to utilize this pull request; However, it may provide greater access to Exfoliate for developers who required these parameters to be available and may improve adoption of the library.

Fixes #2
